### PR TITLE
fix: Solving paragraph error in docs

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -5,7 +5,7 @@ const generateQuote = (e) => {
 
 	const quote = DACIOLO.generate_quote({
 		wrap_with_paragraph_tags: true,
-		paragrahps: number_of_paragraphs ? number_of_paragraphs : 2
+		paragraphs: number_of_paragraphs ? number_of_paragraphs : 2
 	})
 
 	console.log(quote)


### PR DESCRIPTION
Currently, in the docs, when you select how many paragraphs you would like to generate, this behavior is ignored by `main.js` plugin. I fixed the wrong parameter name to solve this problem.